### PR TITLE
Don't append $ALLOW directives each time container starts

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,7 +4,10 @@ MUNIN_CONFIGURATION_FILE=/etc/munin/munin-node.conf
 MUNIN_LOG_FILE=/var/log/munin/munin-node-configure.log
 
 if [ ! -z "$ALLOW" ]; then
-    echo $ALLOW >> $MUNIN_CONFIGURATION_FILE
+    if [ ! -f $MUNIN_CONFIGURATION_FILE.applied ]; then
+        echo $ALLOW >> $MUNIN_CONFIGURATION_FILE
+        touch $MUNIN_CONFIGURATION_FILE.applied
+    fi        
 fi
 
 # if /var/lib/muninplugins/ do exist, soft link to /etc/munin/plugins


### PR DESCRIPTION
Each time the container boots it appends the $ALLOW directives to the end of the munin-node.conf file. Munin does not seem to support multiple cidr_allow directives - you have to specify the cidrs on the same line.

docker-compose.yml example:

```
    munin-node:
        restart: unless-stopped
        image: funkypenguin/munin-node
        networks:
            - monitoring
        volumes:
            - /:/rootfs:ro
            - /sys:/sys:ro
        environment:
            - ALLOW=cidr_allow 0.0.0.0/0
        privileged: true
        ports:
            - "4949:4949"
```

With this we end up with multiple `cidr_allow 0.0.0.0/0` lines added to `/etc/munin/munin-node.conf` in the container which causes them to be ignored. Destroying and recreating the container fixes this but isn't ideal.